### PR TITLE
define IMGUI_DEFINE_MATH_OPERATORS before imgui.h

### DIFF
--- a/imgui_toggle.cpp
+++ b/imgui_toggle.cpp
@@ -1,14 +1,14 @@
-#include "imgui_toggle.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif // IMGUI_DEFINE_MATH_OPERATORS
 
+#include "imgui_toggle.h"
 #include "imgui.h"
+
 #include "imgui_toggle_math.h"
 #include "imgui_toggle_palette.h"
 #include "imgui_toggle_renderer.h"
 
-#ifndef IMGUI_DEFINE_MATH_OPERATORS
-#define IMGUI_DEFINE_MATH_OPERATORS
-#endif // IMGUI_DEFINE_MATH_OPERATORS
-#include "imgui_internal.h"
 
 using namespace ImGuiToggleConstants;
 using namespace ImGuiToggleMath;

--- a/imgui_toggle_math.h
+++ b/imgui_toggle_math.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "imgui.h"
 
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif // IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
 
 namespace ImGuiToggleMath

--- a/imgui_toggle_palette.cpp
+++ b/imgui_toggle_palette.cpp
@@ -1,11 +1,12 @@
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif // IMGUI_DEFINE_MATH_OPERATORS
+
 #include "imgui_toggle_palette.h"
 #include "imgui_toggle_math.h"
 
 #include "imgui.h"
-#ifndef IMGUI_DEFINE_MATH_OPERATORS
-#define IMGUI_DEFINE_MATH_OPERATORS
-#endif // IMGUI_DEFINE_MATH_OPERATORS
-#include "imgui_internal.h"
+
 
 using namespace ImGuiToggleMath;
 

--- a/imgui_toggle_renderer.h
+++ b/imgui_toggle_renderer.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "imgui.h"
-#include "imgui_toggle.h"
-#include "imgui_toggle_palette.h"
-
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif // IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
+
+#include "imgui_toggle.h"
+#include "imgui_toggle_palette.h"
+
 
 class ImGuiToggleRenderer
 {


### PR DESCRIPTION
Hi, 

This is a simple PR that adapts to imgui's new API: IMGUI_DEFINE_MATH_OPERATORS should be defined before including imgui.h (not only imgui_internal.h)

See [Release v1.89.4](https://github.com/ocornut/imgui/releases/tag/v1.89.4)

