### PR TITLE
Adapt to new IMGUI_TEST_ENGINE_ITEM_INFO API

### DIFF
--- a/imgui_toggle_renderer.cpp
+++ b/imgui_toggle_renderer.cpp
@@ -49,7 +49,7 @@ bool ImGuiToggleRenderer::Render()
     }
 
     // update igui context
-    g = GImGui;
+    ImGuiContext& g = *GImGui;
     _id = window->GetID(_label);
     _drawList = ImGui::GetWindowDrawList();
     _style = &ImGui::GetStyle();
@@ -127,6 +127,7 @@ bool ImGuiToggleRenderer::ToggleBehavior(const ImRect& interaction_bounding_box)
     ImGui::ItemSize(interaction_bounding_box, _style->FramePadding.y);
     if (!ImGui::ItemAdd(interaction_bounding_box, _id))
     {
+        ImGuiContext& g = *GImGui;
         IMGUI_TEST_ENGINE_ITEM_INFO(_id, _label, g.LastItemData.StatusFlags | ImGuiItemStatusFlags_Checkable | (*_value ? ImGuiItemStatusFlags_Checked : 0));
         return false;
     }
@@ -149,10 +150,11 @@ void ImGuiToggleRenderer::DrawToggle()
     const float height = GetHeight();
     const float width = GetWidth();
 
+    ImGuiContext& g = *GImGui;
     // update imgui state
-    _isHovered = g->HoveredId == _id;
-    _isLastActive = g->LastActiveId == _id;
-    _lastActiveTimer = g->LastActiveIdTimer;
+    _isHovered = g.HoveredId == _id;
+    _isLastActive = g.LastActiveId == _id;
+    _lastActiveTimer = g.LastActiveIdTimer;
 
     // radius is by default half the diameter
     const float knob_radius = height * DiameterToRadiusRatio;
@@ -358,7 +360,8 @@ void ImGuiToggleRenderer::DrawLabel(float x_offset)
     const float label_y = _boundingBox.Min.y + half_height - (label_size.y * 0.5f);
     const ImVec2 label_pos = ImVec2(label_x, label_y);
 
-    if (g->LogEnabled)
+    ImGuiContext& g = *GImGui;
+    if (g.LogEnabled)
     {
         ImGui::LogRenderedText(&label_pos, _isMixedValue ? "[~]" : *_value ? "[x]" : "[ ]");
     }

--- a/imgui_toggle_renderer.h
+++ b/imgui_toggle_renderer.h
@@ -30,7 +30,6 @@ private:
     float _animationPercent;
 
     // imgui specific context
-    const ImGuiContext* g;
     const ImGuiStyle* _style;
     ImDrawList* _drawList;
     ImGuiID _id;


### PR DESCRIPTION
Hi, here is another PR that adapts the API of IMGUI_TEST_ENGINE_ITEM_INFO

The classic way to use it is as below:

    ImGuiContext& g = *GImGui;
    IMGUI_TEST_ENGINE_ITEM_INFO(id, str_id, g.LastItemData.StatusFlags);

(extract from imgui_widgets.cpp)

I removed the `ImGuiContext * g` member and wrote `ImGuiContext& g = *GImGui;` whenever needed