### PR TITLE
Make iOS and material style DPI aware

### DIFF
--- a/imgui_toggle_presets.cpp
+++ b/imgui_toggle_presets.cpp
@@ -11,6 +11,12 @@ namespace
     const ImVec4 GreenHighlight(0.3f, 1.0f, 0.0f, 0.75f);
     const ImVec4 RedHighlight(1.0f, 0.3f, 0.0f, 0.75f);
 
+    // DPI aware scale utility: the scale should proportional to the font size
+    // font Size is typically 14.5 on normal DPI screens, and 29 on windows HighDPI
+    float DpiFactor()
+    {
+        return ImGui::GetFontSize() / 14.5f;
+    }
 } // namespace
 
 ImGuiToggleConfig ImGuiTogglePresets::DefaultStyle()
@@ -47,8 +53,11 @@ ImGuiToggleConfig ImGuiTogglePresets::GlowingStyle()
     return config;
 }
 
-ImGuiToggleConfig ImGuiTogglePresets::iOSStyle(const float size_scale /*= 1.0f*/, bool light_mode /*= false*/)
+
+ImGuiToggleConfig ImGuiTogglePresets::iOSStyle(const float _size_scale /*= 1.0f*/, bool light_mode /*= false*/)
 {
+    float size_scale = _size_scale * DpiFactor();
+
     const ImVec4 frame_on(0.3f, 0.85f, 0.39f, 1.0f);
     const ImVec4 frame_on_hover(0.0f, 1.0f, 0.57f, 1.0f);
     const ImVec4 dark_mode_frame_off(0.22f, 0.22f, 0.24f, 1.0f);
@@ -109,8 +118,10 @@ ImGuiToggleConfig ImGuiTogglePresets::iOSStyle(const float size_scale /*= 1.0f*/
     return config;
 }
 
-ImGuiToggleConfig ImGuiTogglePresets::MaterialStyle(float size_scale /*= 1.0f*/)
+ImGuiToggleConfig ImGuiTogglePresets::MaterialStyle(float _size_scale /*= 1.0f*/)
 {
+    float size_scale = DpiFactor() * _size_scale;
+
     const ImVec4 purple(0.4f, 0.08f, 0.97f, 1.0f);
     const ImVec4 purple_dim(0.78f, 0.65f, 0.99f, 1.0f);
     const ImVec4 purple_hover(0.53f, 0.08f, 1.0f, 1.0f);
@@ -135,8 +146,10 @@ ImGuiToggleConfig ImGuiTogglePresets::MaterialStyle(float size_scale /*= 1.0f*/)
     return config;
 }
 
-ImGuiToggleConfig ImGuiTogglePresets::MinecraftStyle(float size_scale /*= 1.0f*/)
+ImGuiToggleConfig ImGuiTogglePresets::MinecraftStyle(float _size_scale /*= 1.0f*/)
 {
+    float size_scale = DpiFactor() * _size_scale;
+
     const ImVec4 gray(0.35f, 0.35f, 0.35f, 1.0f);
     const ImVec4 dark_gray(0.12f, 0.12f, 0.12f, 1.0f);
     const ImVec4 frame_border_off(0.6f, 0.6f, 0.61f, 1.0f);


### PR DESCRIPTION
When using ImGui under windows with a HighDPI screen, it is often the case that it is required to double the font size (otherwise, all the widgets appears too small).

In that case, the toggle may appear much too small. A good way to detect High DPI is to look at the default font size, and multiply your widgets' sizes accordingly.

----

For more info: 

I submitted a related PR to ImGui that propose [the addition of `EmSize` and `EmVec2`](https://github.com/ocornut/imgui/pull/6145). It was well received, but not merged.

If you are interested in more details about DPI handling, I wrote a faq article in imgui_bundle about it:
[FAQ Article](https://github.com/pthom/imgui_bundle/blob/doc/bindings/imgui_bundle/doc/imgui_bundle_demo_parts/ibd_faq.adoc.md#high-dpi-with-helloimgui-and-imgui-bundle)


