### PR TITLE
bugfix(imgui_toggle_renderer.cpp): Fix compilation error related to renamed member variables in the latest dear imgui version

### DIFF
--- a/imgui_toggle_renderer.cpp
+++ b/imgui_toggle_renderer.cpp
@@ -10,7 +10,7 @@ namespace
     // a small helper to quickly check the mixed value flag.
     inline bool IsItemMixedValue()
     {
-        return (GImGui->LastItemData.InFlags & ImGuiItemFlags_MixedValue) != 0;
+        return (GImGui->LastItemData.ItemFlags & ImGuiItemFlags_MixedValue) != 0;
     }
 } // namespace
 

--- a/imgui_toggle_renderer.cpp
+++ b/imgui_toggle_renderer.cpp
@@ -10,7 +10,11 @@ namespace
     // a small helper to quickly check the mixed value flag.
     inline bool IsItemMixedValue()
     {
+#if IMGUI_VERSION_NUM >= 19135
         return (GImGui->LastItemData.ItemFlags & ImGuiItemFlags_MixedValue) != 0;
+#else
+        return (GImGui->LastItemData.InFlags & ImGuiItemFlags_MixedValue) != 0;
+#endif
     }
 } // namespace
 


### PR DESCRIPTION
The following commit [e6b5caf](https://github.com/ocornut/imgui/commit/e6b5cafe65fd983eb87bf2fd4d7f68e544911fcd) in the dear imgui repository renames `InFlags` to `ItemFlags` which breaks compilation of the library with the latest dear imgui version that has released yesterday. This PR fixes this compilation issue