### PR TITLE
Fix for ImGui 1.92.8 AddRect arg swap

### DIFF
--- a/imgui_toggle_renderer.cpp
+++ b/imgui_toggle_renderer.cpp
@@ -490,7 +490,11 @@ void ImGuiToggleRenderer::DrawRectBorder(ImRect bounds, ImU32 color_border, floa
     const float half_thickness = thickness * 0.5f;
     bounds.Expand(-half_thickness);
 
+#if IMGUI_VERSION_NUM < 19276
     _drawList->AddRect(bounds.Min, bounds.Max, color_border, rounding, ImDrawFlags_None, thickness);
+#else
+    _drawList->AddRect(bounds.Min, bounds.Max, color_border, rounding, thickness);
+#endif
 }
 
 void ImGuiToggleRenderer::DrawCircleBorder(const ImVec2& center, float radius, ImU32 color_border, float thickness)
@@ -511,7 +515,11 @@ void ImGuiToggleRenderer::DrawRectShadow(ImRect bounds, ImU32 color_shadow, floa
     const float half_thickness = thickness * 0.5f;
     bounds.Expand(half_thickness);
 
+#if IMGUI_VERSION_NUM < 19276
     _drawList->AddRect(bounds.Min, bounds.Max, color_shadow, rounding, ImDrawFlags_None, thickness);
+#else
+    _drawList->AddRect(bounds.Min, bounds.Max, color_shadow, rounding, thickness);
+#endif
 }
 
 void ImGuiToggleRenderer::DrawCircleShadow(const ImVec2& center, float radius, ImU32 color_border, float thickness)


### PR DESCRIPTION
Gate the 2 AddRect call sites on IMGUI_VERSION_NUM < 19276 
last two args (flags, thickness) were swapped to (thickness, flags) in ocornut/imgui v1.92.8.

See https://github.com/ocornut/imgui/releases/tag/v1.92.8
