### PR TITLE
Fix build against ImGui >= 1.92.8 (ImLerp cannot take ImOffsetRect)

### DIFF
--- a/imgui_offset_rect.h
+++ b/imgui_offset_rect.h
@@ -39,3 +39,13 @@ static inline ImOffsetRect operator+(const ImOffsetRect& lhs, const ImOffsetRect
 static inline ImOffsetRect operator-(const ImOffsetRect& lhs, const ImOffsetRect& rhs) { return ImOffsetRect(lhs.Top - rhs.Top, lhs.Left - rhs.Left, lhs.Bottom - rhs.Bottom, lhs.Right - rhs.Right); }
 static inline ImOffsetRect operator*(const ImOffsetRect& lhs, const ImOffsetRect& rhs) { return ImOffsetRect(lhs.Top * rhs.Top, lhs.Left * rhs.Left, lhs.Bottom * rhs.Bottom, lhs.Right * rhs.Right); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
+
+// ImGui 1.92.8 (19274) changed the generic ImLerp to `(T)((float)a + (float)(b - a) * t)`, which needs a
+// T -> float conversion. ImOffsetRect only converts the other way (its float constructor), so the
+// template fails to instantiate and imgui_toggle_renderer.cpp's KnobInset/KnobOffset lerps stop
+// compiling. An exact-match overload wins over the template and keeps the same component-wise result.
+#if IMGUI_VERSION_NUM >= 19274
+IM_MSVC_RUNTIME_CHECKS_OFF
+static inline ImOffsetRect ImLerp(ImOffsetRect a, ImOffsetRect b, float t) { return (a + (b - a) * t); }
+IM_MSVC_RUNTIME_CHECKS_RESTORE
+#endif // IMGUI_VERSION_NUM >= 19274


### PR DESCRIPTION
### Body

```markdown
Closes #21.

### Problem

`imgui_toggle` does not compile against any ImGui >= 1.92.8.

1.92.8 redefined the generic lerp in `imgui_internal.h`:

```cpp
// <= 1.92.2b
template<typename T> T ImLerp(T a, T b, float t) { return (T)(a + (b - a) * t); }

// >= 1.92.8  (ocornut/imgui@f2f843c)
template<typename T> T ImLerp(T a, T b, float t) { return (T)((float)a + (float)(b - a) * t); }
```

The new form needs a `T -> float` conversion. `ImOffsetRect` only converts the *other* way (via its
`ImOffsetRect(float all)` constructor), so instantiating the template fails — and
`ImGuiToggleRenderer::UpdateState()` lerps two of them:

```cpp
// imgui_toggle_renderer.cpp:409-410
_state.KnobInset  = ImLerp(_config.Off.KnobInset,  _config.On.KnobInset,  _animationPercent);
_state.KnobOffset = ImLerp(_config.Off.KnobOffset, _config.On.KnobOffset, _animationPercent);
```

giving:

```
imgui_internal.h(524): error C2440: 'type cast': cannot convert from 'ImOffsetRect' to 'float'
        with [ T=ImOffsetRect ]
imgui_toggle_renderer.cpp(409): note: see reference to function template instantiation
        'T ImLerp<ImOffsetRect>(T,T,float)' being compiled
```

Pinning an older ImGui is not a way out: #20 ("Fix for ImGui 1.92.8 AddRect arg swap") already requires
>= 1.92.8, so going older just trades this break for the `AddRect` one. Right now there is no ImGui
version that builds.

### Fix

This is **@nitz's own fix from #21**, unchanged — an exact-match `ImLerp` overload for `ImOffsetRect` at
the end of `imgui_offset_rect.h`, guarded on `IMGUI_VERSION_NUM >= 19274`:

```cpp
#if IMGUI_VERSION_NUM >= 19274
static inline ImOffsetRect ImLerp(ImOffsetRect a, ImOffsetRect b, float t) { return (a + (b - a) * t); }
#endif
```

An exact match beats ImGui's template during overload resolution, so the two call sites above pick it up
with no other change. The result is identical to what the old template produced: `t` converts to
`ImOffsetRect(t,t,t,t)` and the existing `operator*` multiplies component-wise.

I added only a comment explaining why it exists and `IM_MSVC_RUNTIME_CHECKS_OFF/RESTORE` to match the
neighbouring operators.

#21 was closed as completed, but the fix only ever existed as a comment — so anyone cloning `main` still
hits this. This commits it.

### Verification

- Builds against ImGui `1.92.8` (`IMGUI_VERSION_NUM 19280`), MSVC, `/std:c++17 /W4`, no warnings.
- Toggle animation unchanged (knob inset/offset still interpolate).
- No effect on ImGui < 19274 (guarded out).
```